### PR TITLE
Fix faction tooltip text and Resistance icon rendering

### DIFF
--- a/frontend/src/lib/data/factions.ts
+++ b/frontend/src/lib/data/factions.ts
@@ -39,16 +39,47 @@ export const FACTION_LABELS: Record<string, string> = {
 
 export const ALL_FACTIONS = Object.keys(FACTION_COLORS).filter(f => f !== 'unknown');
 
-export function getFactionColor(factionXws: string): string {
-    return FACTION_COLORS[factionXws] ?? FACTION_COLORS.unknown;
+const FACTION_ALIASES: Record<string, string> = {
+    rebel: 'rebelalliance',
+    empire: 'galacticempire',
+    scum: 'scumandvillainy',
+    resistance: 'resistance',
+    firstorder: 'firstorder',
+    republic: 'galacticrepublic',
+    separatist: 'separatistalliance'
+};
+
+function coerceFactionValue(value: unknown): string {
+    return String(value ?? '').trim();
 }
 
-export function getFactionChar(factionXws: string): string {
-    return FACTION_CHARS[factionXws] ?? '?';
+export function normalizeFactionKey(value: unknown): string {
+    const normalized = coerceFactionValue(value).toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (!normalized) return 'unknown';
+    if (normalized in FACTION_COLORS) return normalized;
+
+    for (const [alias, faction] of Object.entries(FACTION_ALIASES)) {
+        if (normalized === alias || normalized.includes(alias)) {
+            return faction;
+        }
+    }
+
+    return 'unknown';
 }
 
-export function getFactionLabel(factionXws: string): string {
-    return FACTION_LABELS[factionXws] ?? factionXws;
+export function getFactionColor(factionXws: unknown): string {
+    const key = normalizeFactionKey(factionXws);
+    return FACTION_COLORS[key] ?? FACTION_COLORS.unknown;
+}
+
+export function getFactionChar(factionXws: unknown): string {
+    const key = normalizeFactionKey(factionXws);
+    return FACTION_CHARS[key] ?? FACTION_CHARS.unknown;
+}
+
+export function getFactionLabel(factionXws: unknown): string {
+    const key = normalizeFactionKey(factionXws);
+    return FACTION_LABELS[key] ?? (coerceFactionValue(factionXws) || FACTION_LABELS.unknown);
 }
 
 /**

--- a/frontend/src/lib/data/factions.ts
+++ b/frontend/src/lib/data/factions.ts
@@ -39,47 +39,16 @@ export const FACTION_LABELS: Record<string, string> = {
 
 export const ALL_FACTIONS = Object.keys(FACTION_COLORS).filter(f => f !== 'unknown');
 
-const FACTION_ALIASES: Record<string, string> = {
-    rebel: 'rebelalliance',
-    empire: 'galacticempire',
-    scum: 'scumandvillainy',
-    resistance: 'resistance',
-    firstorder: 'firstorder',
-    republic: 'galacticrepublic',
-    separatist: 'separatistalliance'
-};
-
-function coerceFactionValue(value: unknown): string {
-    return String(value ?? '').trim();
+export function getFactionColor(factionXws: string): string {
+    return FACTION_COLORS[factionXws] ?? FACTION_COLORS.unknown;
 }
 
-export function normalizeFactionKey(value: unknown): string {
-    const normalized = coerceFactionValue(value).toLowerCase().replace(/[^a-z0-9]/g, '');
-    if (!normalized) return 'unknown';
-    if (normalized in FACTION_COLORS) return normalized;
-
-    for (const [alias, faction] of Object.entries(FACTION_ALIASES)) {
-        if (normalized === alias || normalized.includes(alias)) {
-            return faction;
-        }
-    }
-
-    return 'unknown';
+export function getFactionChar(factionXws: string): string {
+    return FACTION_CHARS[factionXws] ?? FACTION_CHARS.unknown;
 }
 
-export function getFactionColor(factionXws: unknown): string {
-    const key = normalizeFactionKey(factionXws);
-    return FACTION_COLORS[key] ?? FACTION_COLORS.unknown;
-}
-
-export function getFactionChar(factionXws: unknown): string {
-    const key = normalizeFactionKey(factionXws);
-    return FACTION_CHARS[key] ?? FACTION_CHARS.unknown;
-}
-
-export function getFactionLabel(factionXws: unknown): string {
-    const key = normalizeFactionKey(factionXws);
-    return FACTION_LABELS[key] ?? (coerceFactionValue(factionXws) || FACTION_LABELS.unknown);
+export function getFactionLabel(factionXws: string): string {
+    return FACTION_LABELS[factionXws] ?? factionXws;
 }
 
 /**

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -2,7 +2,11 @@
     import { browser } from "$app/environment";
     import { filters } from "$lib/stores/filters.svelte";
     import ContentSourceToggle from "$lib/components/ContentSourceToggle.svelte";
-    import { getFactionColor, getFactionChar, getFactionLabel } from "$lib/data/factions";
+    import {
+        getFactionColor,
+        getFactionChar,
+        getFactionLabel,
+    } from "$lib/data/factions";
     import { xwingData } from "$lib/stores/xwingData.svelte";
 
     let meta = $state<any>(null);
@@ -122,20 +126,6 @@
         return "xwing-miniatures-ship-" + xws.replace(/[^a-z0-9]/g, "");
     }
 
-    function getFactionIconClass(xws: string) {
-        const normalized = (xws || "").toLowerCase().replace(/[^a-z0-9]/g, "");
-        const icons: Record<string, string> = {
-            rebelalliance: "xwing-miniatures-font-rebel",
-            galacticempire: "xwing-miniatures-font-empire",
-            scumandvillainy: "xwing-miniatures-font-scum",
-            resistance: "xwing-miniatures-font-resistance",
-            firstorder: "xwing-miniatures-font-firstorder",
-            galacticrepublic: "xwing-miniatures-font-republic",
-            separatistalliance: "xwing-miniatures-font-separatists",
-        };
-        return icons[normalized] || "";
-    }
-
     function getUpgradeIconClass(type: string) {
         if (!type) return "";
         return (
@@ -180,10 +170,6 @@
         return items.filter((item) =>
             Number(item?.games_count ?? item?.games ?? 0) >= minGames,
         );
-    }
-
-    function getFactionKey(value: unknown): string {
-        return String(value ?? "unknown").toLowerCase();
     }
 
     function getPilotDisplay(pilotXws: string) {
@@ -262,6 +248,15 @@
                 borderWidth: 1,
                 titleFont: { family: '"Inter", sans-serif' },
                 bodyFont: { family: '"Inter", sans-serif' },
+                callbacks: {
+                    title(tooltipItems: { dataIndex: number; label?: string }[]) {
+                        const item = tooltipItems[0];
+                        const faction = item ? meta?.factions?.[item.dataIndex] : null;
+                        return faction
+                            ? getFactionLabel(faction.xws)
+                            : item?.label ?? "";
+                    },
+                },
             },
         },
         scales: {
@@ -563,20 +558,20 @@
                 </div>
                 <div class="flex flex-wrap justify-center w-full mt-2">
                     {#each meta.factions || [] as dist}
-                        {@const factionXws = getFactionKey(dist.xws)}
                         {@const pct = totalFactionGames > 0
                             ? (((dist.games_count || 0) / totalFactionGames) * 100).toFixed(1)
                             : "0.0"}
                         <div
                             class="flex items-center gap-[6px] text-xs font-mono text-secondary mr-3 mb-[6px]"
                         >
-                            <i
-                                class="xwing-miniatures-font {getFactionIconClass(
-                                    factionXws,
-                                )} text-sm"
-                                style="color: {getFactionColor(factionXws)}"
-                            ></i>
-                            <span>{getFactionLabel(factionXws)} {pct}%</span>
+                            <span
+                                class="font-xwing xwing-icon text-sm"
+                                style="color: {getFactionColor(dist.xws)}"
+                                aria-hidden="true"
+                            >
+                                {getFactionChar(dist.xws)}
+                            </span>
+                            <span>{getFactionLabel(dist.xws)} {pct}%</span>
                         </div>
                     {/each}
                 </div>
@@ -641,14 +636,13 @@
                                     <div
                                         class="flex items-center gap-1 min-w-0 mt-0.5"
                                     >
-                                        <i
-                                            class="xwing-miniatures-font {getFactionIconClass(
-                                                p.faction,
-                                            )} text-[11px]"
-                                            style="color: {getFactionColor(
-                                                p.faction,
-                                            )}"
-                                        ></i>
+                                        <span
+                                            class="font-xwing xwing-icon text-[11px]"
+                                            style="color: {getFactionColor(p.faction)}"
+                                            aria-hidden="true"
+                                        >
+                                            {getFactionChar(p.faction)}
+                                        </span>
                                         <span
                                             class="text-[12px] text-secondary truncate min-w-0 pointer-events-none"
                                         >
@@ -788,7 +782,7 @@
                     {#each sortedShips.slice(0, 5) as ship}
                         {@const shipData = xwingData.getShip(ship.xws)}
                         {@const shipName = shipData?.name || ship.xws}
-                        {@const factionXws = getFactionKey(ship.faction_xws)}
+                        {@const factionXws = ship.faction_xws}
                         {@const wr = getWinRate(ship.wins || 0, ship.games_count || 0)}
                         <div
                             class="py-[12px] border-b border-border-dark flex items-center justify-between w-full last:border-0 relative"
@@ -816,14 +810,13 @@
                                     <div
                                         class="flex items-center gap-1 min-w-0 mt-0.5"
                                     >
-                                        <i
-                                            class="xwing-miniatures-font {getFactionIconClass(
-                                                factionXws,
-                                            )} text-[11px]"
-                                            style="color: {getFactionColor(
-                                                factionXws,
-                                            )}"
-                                        ></i>
+                                        <span
+                                            class="font-xwing xwing-icon text-[11px]"
+                                            style="color: {getFactionColor(factionXws)}"
+                                            aria-hidden="true"
+                                        >
+                                            {getFactionChar(factionXws)}
+                                        </span>
                                         <span
                                             class="text-[12px] text-secondary truncate min-w-0 pointer-events-none"
                                             >{getFactionLabel(factionXws)}</span
@@ -879,7 +872,7 @@
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-4 gap-6 w-full">
                     {#each sortedLists.slice(0, 4) as list}
-                        {@const factionXws = getFactionKey(list.faction_xws)}
+                        {@const factionXws = list.faction_xws}
                         {@const wr = getWinRate(list.wins || 0, list.games || 0)}
                         <div
                             class="p-4 bg-[rgba(255,255,255,0.01)] border border-border-dark hover:bg-[rgba(255,255,255,0.03)] transition-colors cursor-pointer w-full flex flex-col gap-3 rounded-md"
@@ -890,14 +883,13 @@
                                 <div
                                     class="flex items-center gap-2 overflow-hidden mr-2 h-12"
                                 >
-                                    <i
-                                        class="xwing-miniatures-font {getFactionIconClass(
-                                            factionXws,
-                                        )} text-2xl flex-shrink-0"
-                                        style="color: {getFactionColor(
-                                            factionXws,
-                                        )}"
-                                    ></i>
+                                    <span
+                                        class="font-xwing xwing-icon text-2xl flex-shrink-0"
+                                        style="color: {getFactionColor(factionXws)}"
+                                        aria-hidden="true"
+                                    >
+                                        {getFactionChar(factionXws)}
+                                    </span>
                                     <div class="flex flex-col min-w-0">
                                         <span
                                             class="text-base font-bold text-primary line-clamp-2 leading-tight"

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -126,6 +126,20 @@
         return "xwing-miniatures-ship-" + xws.replace(/[^a-z0-9]/g, "");
     }
 
+    function getFactionIconClass(xws: string) {
+        const normalized = (xws || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+        const icons: Record<string, string> = {
+            rebelalliance: "xwing-miniatures-font-rebel",
+            galacticempire: "xwing-miniatures-font-empire",
+            scumandvillainy: "xwing-miniatures-font-scum",
+            resistance: "xwing-miniatures-font-resistance",
+            firstorder: "xwing-miniatures-font-firstorder",
+            galacticrepublic: "xwing-miniatures-font-republic",
+            separatistalliance: "xwing-miniatures-font-separatists",
+        };
+        return icons[normalized] || "";
+    }
+
     function getUpgradeIconClass(type: string) {
         if (!type) return "";
         return (
@@ -564,13 +578,12 @@
                         <div
                             class="flex items-center gap-[6px] text-xs font-mono text-secondary mr-3 mb-[6px]"
                         >
-                            <span
-                                class="font-xwing xwing-icon text-sm"
+                            <i
+                                class="xwing-miniatures-font {getFactionIconClass(
+                                    dist.xws,
+                                )} text-sm"
                                 style="color: {getFactionColor(dist.xws)}"
-                                aria-hidden="true"
-                            >
-                                {getFactionChar(dist.xws)}
-                            </span>
+                            ></i>
                             <span>{getFactionLabel(dist.xws)} {pct}%</span>
                         </div>
                     {/each}
@@ -636,13 +649,14 @@
                                     <div
                                         class="flex items-center gap-1 min-w-0 mt-0.5"
                                     >
-                                        <span
-                                            class="font-xwing xwing-icon text-sm"
-                                            style="color: {getFactionColor(p.faction)}"
-                                            aria-hidden="true"
-                                        >
-                                            {getFactionChar(p.faction)}
-                                        </span>
+                                        <i
+                                            class="xwing-miniatures-font {getFactionIconClass(
+                                                p.faction,
+                                            )} text-[11px]"
+                                            style="color: {getFactionColor(
+                                                p.faction,
+                                            )}"
+                                        ></i>
                                         <span
                                             class="text-[12px] text-secondary truncate min-w-0 pointer-events-none"
                                         >
@@ -810,13 +824,14 @@
                                     <div
                                         class="flex items-center gap-1 min-w-0 mt-0.5"
                                     >
-                                        <span
-                                            class="font-xwing xwing-icon text-sm"
-                                            style="color: {getFactionColor(factionXws)}"
-                                            aria-hidden="true"
-                                        >
-                                            {getFactionChar(factionXws)}
-                                        </span>
+                                        <i
+                                            class="xwing-miniatures-font {getFactionIconClass(
+                                                factionXws,
+                                            )} text-[11px]"
+                                            style="color: {getFactionColor(
+                                                factionXws,
+                                            )}"
+                                        ></i>
                                         <span
                                             class="text-[12px] text-secondary truncate min-w-0 pointer-events-none"
                                             >{getFactionLabel(factionXws)}</span

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -608,7 +608,7 @@
                     </div>
                 </div>
                 <div class="w-full flex flex-col">
-                    {#each sortedPilots.slice(0, 5) as pilot}
+                    {#each sortedPilots.slice(0, 6) as pilot}
                         {@const p = getPilotDisplay(pilot.xws)}
                         {@const wr = getWinRate(pilot.wins || 0, pilot.games_count || 0)}
                         <div
@@ -779,7 +779,7 @@
                     </div>
                 </div>
                 <div class="w-full flex flex-col">
-                    {#each sortedShips.slice(0, 5) as ship}
+                    {#each sortedShips.slice(0, 6) as ship}
                         {@const shipData = xwingData.getShip(ship.xws)}
                         {@const shipName = shipData?.name || ship.xws}
                         {@const factionXws = ship.faction_xws}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -578,12 +578,13 @@
                         <div
                             class="flex items-center gap-[6px] text-xs font-mono text-secondary mr-3 mb-[6px]"
                         >
-                            <i
-                                class="xwing-miniatures-font {getFactionIconClass(
-                                    dist.xws,
-                                )} text-sm"
+                            <span
+                                class="font-xwing text-sm"
                                 style="color: {getFactionColor(dist.xws)}"
-                            ></i>
+                                aria-hidden="true"
+                            >
+                                {getFactionChar(dist.xws)}
+                            </span>
                             <span>{getFactionLabel(dist.xws)} {pct}%</span>
                         </div>
                     {/each}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -608,7 +608,7 @@
                     </div>
                 </div>
                 <div class="w-full flex flex-col">
-                    {#each sortedPilots.slice(0, 6) as pilot}
+                    {#each sortedPilots.slice(0, 5) as pilot}
                         {@const p = getPilotDisplay(pilot.xws)}
                         {@const wr = getWinRate(pilot.wins || 0, pilot.games_count || 0)}
                         <div
@@ -637,7 +637,7 @@
                                         class="flex items-center gap-1 min-w-0 mt-0.5"
                                     >
                                         <span
-                                            class="font-xwing xwing-icon text-[11px]"
+                                            class="font-xwing xwing-icon text-sm"
                                             style="color: {getFactionColor(p.faction)}"
                                             aria-hidden="true"
                                         >
@@ -779,7 +779,7 @@
                     </div>
                 </div>
                 <div class="w-full flex flex-col">
-                    {#each sortedShips.slice(0, 6) as ship}
+                    {#each sortedShips.slice(0, 5) as ship}
                         {@const shipData = xwingData.getShip(ship.xws)}
                         {@const shipName = shipData?.name || ship.xws}
                         {@const factionXws = ship.faction_xws}
@@ -811,7 +811,7 @@
                                         class="flex items-center gap-1 min-w-0 mt-0.5"
                                     >
                                         <span
-                                            class="font-xwing xwing-icon text-[11px]"
+                                            class="font-xwing xwing-icon text-sm"
                                             style="color: {getFactionColor(factionXws)}"
                                             aria-hidden="true"
                                         >


### PR DESCRIPTION
## Summary

Make faction presentation consistent in the dashboard by showing full faction names in the Faction Performance tooltip and rendering faction badges through the shared glyph helpers so Resistance displays reliably.

Fixes #95
