### PR TITLE
Add response caching to backend API

### DIFF
--- a/CACHING.md
+++ b/CACHING.md
@@ -1,0 +1,200 @@
+# Response Caching Implementation
+
+## Overview
+
+This document describes the response caching system implemented in the M3taCron backend API to improve performance and reduce database load.
+
+## Problem Statement
+
+The M3taCron API performs expensive database aggregations for analytics endpoints (lists, ships, pilots, upgrades, squadrons, and detail routes). Since new tournament data is inserted only **once per day**, most API responses remain static for long periods. Without caching, repeated requests to these endpoints cause unnecessary database queries and slow response times.
+
+## Solution: Time-Based Response Caching
+
+### Architecture
+
+**File**: `backend/cache.py`
+
+The caching system uses a simple in-memory cache with time-to-live (TTL) expiration:
+
+```python
+@cached_response(ttl_seconds=3600)
+def get_lists(...):
+    # API endpoint implementation
+    ...
+```
+
+### Features
+
+- **Automatic Caching**: Decorator-based approach requires minimal code changes
+- **TTL-based Expiration**: Cache entries automatically expire after 1 hour (3600 seconds)
+- **Per-Parameter Caching**: Different parameter combinations create separate cache entries
+- **Manual Invalidation**: Admin endpoint to clear cache immediately after data refresh
+
+### Cached Endpoints
+
+The following endpoints benefit from caching (1-hour TTL):
+
+#### Main Analytics Endpoints
+- `GET /api/lists` - List statistics
+- `GET /api/ships` - Ship statistics
+- `GET /api/ships/all` - All available ships
+- `GET /api/cards/pilots` - Pilot statistics
+- `GET /api/cards/upgrades` - Upgrade statistics
+- `GET /api/squadrons` - Squadron statistics
+
+#### Meta Endpoint
+- `GET /api/meta-snapshot` - Overall meta snapshot (factions, ships, lists, pilots, upgrades, stats)
+
+#### Detail Pages
+- `GET /api/pilot/{pilot_xws}` - Pilot info
+- `GET /api/pilot/{pilot_xws}/upgrades` - Pilot-compatible upgrades
+- `GET /api/pilot/{pilot_xws}/chart` - Pilot usage history
+- `GET /api/pilot/{pilot_xws}/configurations` - Pilot upgrade configurations
+- `GET /api/ship/{ship_xws}` - Ship info
+- `GET /api/ship/{ship_xws}/pilots` - Pilots in this ship
+- `GET /api/ship/{ship_xws}/lists` - Lists using this ship
+- `GET /api/ship/{ship_xws}/squadrons` - Squadrons using this ship
+- `GET /api/squadron/{signature}/stats` - Squadron statistics
+- `GET /api/squadron/{signature}/pilots` - Pilots in this squadron
+- `GET /api/squadron/{signature}/lists` - Lists with this squadron
+- `GET /api/list/{list_id}/stats` - List statistics
+
+## Usage
+
+### For API Users
+
+No changes required. Responses are transparently cached. To get fresh data:
+
+1. Wait for cache expiration (1 hour by default)
+2. OR trigger manual cache invalidation (see below)
+
+### For Administrators: Manual Cache Invalidation
+
+When new tournament data is imported, invalidate the cache immediately:
+
+```bash
+curl -X POST http://localhost:8000/api/cache/invalidate
+```
+
+Response:
+```json
+{
+  "status": "success",
+  "message": "Cache invalidated"
+}
+```
+
+### For Developers: Adjusting Cache TTL
+
+To change the cache time-to-live for any endpoint, modify the `ttl_seconds` parameter:
+
+```python
+@cached_response(ttl_seconds=7200)  # 2 hours
+def get_lists(...):
+    ...
+```
+
+**Recommended TTL values:**
+- `3600` (1 hour): Most analytics endpoints (default)
+- `1800` (30 minutes): Frequently changing data
+- `7200` (2 hours): Static metadata (ships, pilots)
+
+## Implementation Details
+
+### Cache Key Generation
+
+Cache keys are generated from:
+1. Function name
+2. Positional arguments
+3. Keyword arguments
+
+Example:
+```python
+get_lists(
+    page=0,
+    size=20,
+    data_source="xwa",
+    formats=["Extended"],
+    factions=["rebel-alliance"]
+)
+# Generates unique cache key for this parameter combination
+```
+
+Different parameter values create separate cache entries, allowing:
+- Page 0 and Page 1 results to be cached separately
+- XWA and Legacy data sources to be cached independently
+- Filtered and unfiltered results to coexist in cache
+
+### Cache Statistics
+
+Debug cache state:
+
+```python
+from backend.cache import get_cache_stats
+stats = get_cache_stats()
+print(stats)
+# Output: {'total_entries': 5, 'keys': [...]}
+```
+
+## Performance Impact
+
+### Expected Improvements
+
+- **First request**: Full database query (baseline)
+- **Cached requests** (within TTL): ~10-100x faster (instant memory lookup)
+- **After TTL expires**: Returns to baseline (cache expired)
+
+### Memory Overhead
+
+- Negligible for typical API traffic
+- Each cache entry stores: response object + timestamp
+- ~1-10 MB per 100 concurrent cache entries (depends on response size)
+
+## Monitoring
+
+### To Monitor Cache Hits
+
+Add logging to `backend/cache.py` if needed:
+
+```python
+@cached_response(ttl_seconds=3600)
+def cached_func(...):
+    print("Cache miss - executing function")  # Only on cache misses
+    ...
+```
+
+## Future Enhancements
+
+Potential improvements:
+1. **Redis integration**: For distributed/multi-instance deployments
+2. **Cache warmup**: Pre-load common queries on startup
+3. **Partial invalidation**: Clear only specific endpoints (e.g., only lists, not ships)
+4. **Metrics**: Track cache hit rates and effectiveness
+5. **Adaptive TTL**: Adjust TTL based on data freshness
+
+## Troubleshooting
+
+### Cache Not Working?
+
+1. Verify the decorator is applied: Check the function definition in the source code
+2. Check cache stats: `from backend.cache import get_cache_stats; print(get_cache_stats())`
+3. Verify TTL hasn't expired: Check timestamp in cache store
+
+### Cache Not Clearing?
+
+1. Use the `/api/cache/invalidate` endpoint
+2. Or restart the application (cache is in-memory)
+
+### Wrong Data Returned?
+
+If you see stale data:
+1. Wait for TTL to expire (default 1 hour)
+2. Or call `POST /api/cache/invalidate` to clear immediately
+3. Or check if you're using different query parameters (creates separate cache entry)
+
+## References
+
+- **Decorator Pattern**: Python `functools.wraps`
+- **Cache Keys**: MD5 hash of function name + arguments
+- **TTL Mechanism**: `datetime.now()` comparison
+- **Thread Safety**: Current implementation is single-threaded; use locks for concurrent access if needed

--- a/backend/api/cards.py
+++ b/backend/api/cards.py
@@ -3,8 +3,10 @@ from ..analytics.core import aggregate_card_stats
 from ..data_structures.sorting_order import SortingCriteria, SortDirection
 from ..data_structures.data_source import DataSource
 from .schemas import PaginatedPilotsResponse, PaginatedUpgradesResponse
+from ..cache import cached_response
 
 router = APIRouter(prefix="/api/cards", tags=["Cards"])
+
 
 def _build_filters(
     formats: list[str] | None = None,
@@ -40,7 +42,7 @@ def _build_filters(
     player_count_min: int | None = None,
     player_count_max: int | None = None,
 ) -> dict:
-    
+
     # Base sizes mapping
     sizes_dict = {}
     if base_sizes:
@@ -85,13 +87,14 @@ def _build_filters(
 
 
 @router.get("/pilots", response_model=PaginatedPilotsResponse)
+@cached_response(ttl_seconds=3600)
 def get_pilots(
     page: int = Query(0, ge=0),
     size: int = Query(20, ge=1, le=100),
     data_source: str = Query("xwa"),
     sort_metric: str = Query("Popularity"),
     sort_direction: str = Query("desc"),
-    
+
     formats: list[str] | None = Query(None),
     factions: list[str] | None = Query(None),
     ships: list[str] | None = Query(None),
@@ -155,19 +158,20 @@ def get_pilots(
 
     data = aggregate_card_stats(filters, criteria, s_dir, "pilots", ds_enum)
     total = len(data)
-    items = data[page * size : (page + 1) * size]
-    
+    items = data[page * size: (page + 1) * size]
+
     return PaginatedPilotsResponse(items=items, total=total, page=page, size=size)
 
 
 @router.get("/upgrades", response_model=PaginatedUpgradesResponse)
+@cached_response(ttl_seconds=3600)
 def get_upgrades(
     page: int = Query(0, ge=0),
     size: int = Query(20, ge=1, le=100),
     data_source: str = Query("xwa"),
     sort_metric: str = Query("Popularity"),
     sort_direction: str = Query("desc"),
-    
+
     formats: list[str] | None = Query(None),
     factions: list[str] | None = Query(None),
     upgrade_types: list[str] | None = Query(None),
@@ -208,6 +212,6 @@ def get_upgrades(
 
     data = aggregate_card_stats(filters, criteria, s_dir, "upgrades", ds_enum)
     total = len(data)
-    items = data[page * size : (page + 1) * size]
-    
+    items = data[page * size: (page + 1) * size]
+
     return PaginatedUpgradesResponse(items=items, total=total, page=page, size=size)

--- a/backend/api/list_detail.py
+++ b/backend/api/list_detail.py
@@ -6,6 +6,7 @@ from ..analytics.filters import filter_query, get_active_formats
 from ..data_structures.data_source import DataSource
 from .formatters import enrich_list_data
 from ..utils.list_keys import get_list_key
+from ..cache import cached_response
 
 router = APIRouter(prefix="/api/list", tags=["List Detail"])
 
@@ -13,6 +14,7 @@ router = APIRouter(prefix="/api/list", tags=["List Detail"])
 
 
 @router.get("/{list_id:path}/stats")
+@cached_response(ttl_seconds=3600)
 def get_list_stats(
     list_id: str,
     data_source: str = Query("xwa", description="Data source: xwa or legacy"),

--- a/backend/api/lists.py
+++ b/backend/api/lists.py
@@ -3,26 +3,33 @@ from ..analytics.lists import aggregate_list_stats
 from ..data_structures.data_source import DataSource
 from ..data_structures.factions import Faction
 from .schemas import PaginatedListsResponse
+from ..cache import cached_response
 
 router = APIRouter(prefix="/api/lists", tags=["Lists"])
 
 # Helper to match faction filter
+
+
 def _match_faction(f_enum: Faction, allowed_list: list[str]) -> bool:
-    if not allowed_list: return True
+    if not allowed_list:
+        return True
     # allowed_list has strings like "rebelalliance", "rebel", etc.
     # f_enum is normalized.
     # Normalize allowed list
-    norm_allowed = {f.lower().replace(" ", "").replace("-", "") for f in allowed_list}
+    norm_allowed = {f.lower().replace(" ", "").replace("-", "")
+                    for f in allowed_list}
     return f_enum.value.replace("-", "") in norm_allowed
 
+
 @router.get("", response_model=PaginatedListsResponse)
+@cached_response(ttl_seconds=3600)
 def get_lists(
     page: int = Query(0, ge=0),
     size: int = Query(20, ge=1, le=100),
     data_source: str = Query("xwa"),
     sort_metric: str = Query("Games"),
     sort_direction: str = Query("desc"),
-    
+
     formats: list[str] | None = Query(None),
     factions: list[str] | None = Query(None),
     ships: list[str] | None = Query(None),
@@ -56,10 +63,10 @@ def get_lists(
     }
     if formats:
         filters["allowed_formats"] = formats
-        
+
     # Get raw data (already ListData compatible dicts)
     raw_data = aggregate_list_stats(filters, limit=2000, data_source=ds_enum)
-    
+
     filtered_data = []
     for row in raw_data:
         points = row.get("points") or 0
@@ -67,7 +74,7 @@ def get_lists(
         # Faction check
         if factions and not _match_faction(row["faction_xws"], factions):
             continue
-            
+
         if row["games"] < min_games:
             continue
         if points < points_min or points > points_max:
@@ -75,9 +82,9 @@ def get_lists(
 
         row["points"] = points
         filtered_data.append(row)
-        
+
     reverse = sort_direction == "desc"
-    
+
     def get_win_rate(r):
         return r["wins"] / r["games"] if r["games"] > 0 else 0.0
 
@@ -85,12 +92,12 @@ def get_lists(
         filtered_data.sort(key=get_win_rate, reverse=reverse)
     elif sort_metric == "Points Cost":
         filtered_data.sort(key=lambda x: x["points"], reverse=reverse)
-    else: 
+    else:
         filtered_data.sort(key=lambda x: x["games"], reverse=reverse)
-        
+
     total = len(filtered_data)
-    items = filtered_data[page * size : (page + 1) * size]
-    
+    items = filtered_data[page * size: (page + 1) * size]
+
     # Enrichment removed as ListData is structural-data only, and stats are populated.
-    
+
     return PaginatedListsResponse(items=items, total=total, page=page, size=size)

--- a/backend/api/pilot_detail.py
+++ b/backend/api/pilot_detail.py
@@ -16,11 +16,13 @@ from ..utils.xwing_data.upgrades import load_all_upgrades
 from ..database import engine
 from ..models import PlayerStanding, Tournament
 from sqlmodel import Session, select
+from ..cache import cached_response
 
 router = APIRouter(prefix="/api/pilot", tags=["Pilot Detail"])
 
 
 @router.get("/{pilot_xws}")
+@cached_response(ttl_seconds=3600)
 def get_pilot_info(
     pilot_xws: str,
     data_source: str = Query("xwa"),
@@ -33,6 +35,7 @@ def get_pilot_info(
 
 
 @router.get("/{pilot_xws}/upgrades")
+@cached_response(ttl_seconds=3600)
 def get_pilot_upgrades(
     pilot_xws: str,
     data_source: str = Query("xwa"),
@@ -64,6 +67,7 @@ def get_pilot_upgrades(
 
 
 @router.get("/{pilot_xws}/chart")
+@cached_response(ttl_seconds=3600)
 def get_pilot_chart(
     pilot_xws: str,
     data_source: str = Query("xwa"),
@@ -85,6 +89,7 @@ def get_pilot_chart(
 
 
 @router.get("/{pilot_xws}/configurations")
+@cached_response(ttl_seconds=3600)
 def get_pilot_configurations(
     pilot_xws: str,
     data_source: str = Query("xwa"),

--- a/backend/api/ship_detail.py
+++ b/backend/api/ship_detail.py
@@ -14,11 +14,13 @@ from ..data_structures.sorting_order import SortingCriteria, SortDirection
 from ..data_structures.data_source import DataSource
 from ..utils.xwing_data.ships import load_all_ships
 from .formatters import enrich_list_data
+from ..cache import cached_response
 
 router = APIRouter(prefix="/api/ship", tags=["Ship Detail"])
 
 
 @router.get("/{ship_xws}")
+@cached_response(ttl_seconds=3600)
 def get_ship_info(
     ship_xws: str,
     data_source: str = Query("xwa"),
@@ -40,6 +42,7 @@ def get_ship_info(
 
 
 @router.get("/{ship_xws}/pilots")
+@cached_response(ttl_seconds=3600)
 def get_ship_pilots(
     ship_xws: str,
     data_source: str = Query("xwa"),
@@ -65,6 +68,7 @@ def get_ship_pilots(
 
 
 @router.get("/{ship_xws}/lists")
+@cached_response(ttl_seconds=3600)
 def get_ship_lists(
     ship_xws: str,
     data_source: str = Query("xwa"),
@@ -85,6 +89,7 @@ def get_ship_lists(
 
 
 @router.get("/{ship_xws}/squadrons")
+@cached_response(ttl_seconds=3600)
 def get_ship_squadrons(
     ship_xws: str,
     data_source: str = Query("xwa"),

--- a/backend/api/ships.py
+++ b/backend/api/ships.py
@@ -4,10 +4,12 @@ from ..data_structures.sorting_order import SortingCriteria, SortDirection
 from ..data_structures.data_source import DataSource
 from .schemas import PaginatedShipsResponse
 from ..utils.xwing_data.ships import load_all_ships
+from ..cache import cached_response
 
 router = APIRouter(prefix="/api/ships", tags=["Ships"])
 
 @router.get("/all")
+@cached_response(ttl_seconds=3600)
 def get_all_ships(data_source: str = Query("xwa")):
     """Return every chassis once, with all playable factions merged."""
     ds_enum = DataSource(data_source) if data_source in ("xwa", "legacy") else DataSource.XWA
@@ -30,6 +32,7 @@ def get_all_ships(data_source: str = Query("xwa")):
     return results
 
 @router.get("", response_model=PaginatedShipsResponse)
+@cached_response(ttl_seconds=3600)
 def get_ships(
     page: int = Query(0, ge=0),
     size: int = Query(20, ge=1, le=100),

--- a/backend/api/squadron_detail.py
+++ b/backend/api/squadron_detail.py
@@ -6,10 +6,12 @@ from ..analytics.filters import filter_query, get_active_formats
 from ..analytics.lists import aggregate_list_stats
 from ..data_structures.data_source import DataSource
 from .formatters import enrich_list_data
+from ..cache import cached_response
 
 router = APIRouter(prefix="/api/squadron", tags=["Squadron Detail"])
 
 @router.get("/{signature:path}/stats")
+@cached_response(ttl_seconds=3600)
 def get_squadron_stats(
     signature: str,
     data_source: str = Query("xwa", description="Data source: xwa or legacy"),
@@ -86,6 +88,7 @@ def get_squadron_stats(
         }
 
 @router.get("/{signature:path}/pilots")
+@cached_response(ttl_seconds=3600)
 def get_squadron_pilots(
     signature: str,
     data_source: str = Query("xwa", description="Data source: xwa or legacy"),
@@ -171,6 +174,7 @@ def get_squadron_pilots(
     return results
 
 @router.get("/{signature:path}/lists")
+@cached_response(ttl_seconds=3600)
 def get_squadron_lists(
     signature: str,
     data_source: str = Query("xwa", description="Data source: xwa or legacy"),

--- a/backend/api/squadrons.py
+++ b/backend/api/squadrons.py
@@ -4,10 +4,12 @@ from ..data_structures.data_source import DataSource
 from ..data_structures.sorting_order import SortingCriteria, SortDirection
 from .schemas import PaginatedListsResponse, ListData, PilotData
 from ..utils.xwing_data.ships import get_ship_icon_name
+from ..cache import cached_response
 
 router = APIRouter(prefix="/api/squadrons", tags=["Squadrons"])
 
 @router.get("")
+@cached_response(ttl_seconds=3600)
 def get_squadrons(
     page: int = Query(0, ge=0),
     size: int = Query(20, ge=1, le=100),

--- a/backend/cache.py
+++ b/backend/cache.py
@@ -1,0 +1,87 @@
+"""
+Response caching utility for API endpoints.
+Provides time-based caching for frequently accessed endpoints that don't change often.
+"""
+import functools
+import hashlib
+import json
+from datetime import datetime, timedelta
+from typing import Any, Callable, Optional
+
+# In-memory cache storage
+_CACHE_STORE: dict[str, tuple[Any, datetime]] = {}
+
+
+def _generate_cache_key(func_name: str, args: tuple, kwargs: dict) -> str:
+    """Generate a unique cache key based on function name and arguments."""
+    key_data = {
+        "func": func_name,
+        "args": [str(arg) for arg in args],
+        "kwargs": {k: str(v) for k, v in kwargs.items()},
+    }
+    key_str = json.dumps(key_data, sort_keys=True)
+    return hashlib.md5(key_str.encode()).hexdigest()
+
+
+def cached_response(ttl_seconds: int = 3600):
+    """
+    Decorator to cache API response for a specified TTL.
+
+    Args:
+        ttl_seconds: Time-to-live in seconds (default: 1 hour)
+
+    Usage:
+        @cached_response(ttl_seconds=3600)
+        def get_lists(...):
+            ...
+    """
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs) -> Any:
+            # Generate cache key
+            cache_key = _generate_cache_key(func.__name__, args, kwargs)
+            now = datetime.now()
+
+            # Check if cached value exists and is still valid
+            if cache_key in _CACHE_STORE:
+                cached_value, cached_time = _CACHE_STORE[cache_key]
+                if now - cached_time < timedelta(seconds=ttl_seconds):
+                    return cached_value
+
+            # Call function and cache result
+            result = func(*args, **kwargs)
+            _CACHE_STORE[cache_key] = (result, now)
+
+            return result
+
+        return wrapper
+
+    return decorator
+
+
+def clear_cache():
+    """Clear all cached responses."""
+    global _CACHE_STORE
+    _CACHE_STORE.clear()
+
+
+def clear_cache_for(pattern: Optional[str] = None):
+    """
+    Clear cache entries matching a pattern.
+    If pattern is None, clears all cache.
+    """
+    global _CACHE_STORE
+    if pattern is None:
+        _CACHE_STORE.clear()
+    else:
+        keys_to_remove = [k for k in _CACHE_STORE.keys() if pattern in k]
+        for key in keys_to_remove:
+            del _CACHE_STORE[key]
+
+
+def get_cache_stats() -> dict:
+    """Return cache statistics."""
+    return {
+        "total_entries": len(_CACHE_STORE),
+        "keys": list(_CACHE_STORE.keys()),
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from .api.ship_detail import router as ship_detail_router
 from .api.squadron_detail import router as squadron_detail_router
 from .api.list_detail import router as list_detail_router
 from .api.support import router as support_router
+from .cache import cached_response, clear_cache
 
 app = FastAPI(title="M3taCron Backend", version="1.0.0")
 
@@ -71,6 +72,7 @@ def read_root():
 
 
 @app.get("/api/meta-snapshot", response_model=MetaSnapshotResponse)
+@cached_response(ttl_seconds=3600)
 def get_snapshot(data_source: str = Query("xwa", description="Data source: xwa or legacy")):
     ds_enum = DataSource.XWA if data_source == "xwa" else DataSource.LEGACY
     
@@ -109,3 +111,10 @@ def get_snapshot(data_source: str = Query("xwa", description="Data source: xwa o
         total_tournaments=total_tournaments,
         total_players=total_players
     )
+
+
+@app.post("/api/cache/invalidate")
+def invalidate_cache():
+    """Manually invalidate all cached responses. Used after data refresh."""
+    clear_cache()
+    return {"status": "success", "message": "Cache invalidated"}

--- a/frontend/src/lib/server/backend-api.ts
+++ b/frontend/src/lib/server/backend-api.ts
@@ -1,0 +1,49 @@
+function normalizeBackendApiBase(raw: string): string {
+	const trimmed = raw.trim().replace(/\/+$/, '');
+	return trimmed.endsWith('/api') ? trimmed : `${trimmed}/api`;
+}
+
+function isLocalHostname(hostname: string): boolean {
+	return (
+		hostname === 'localhost' ||
+		hostname === '127.0.0.1' ||
+		hostname === '0.0.0.0' ||
+		/^10\./.test(hostname) ||
+		/^127\./.test(hostname) ||
+		/^192\.168\./.test(hostname) ||
+		/^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname)
+	);
+}
+
+function resolvePreviewBackendBase(hostname: string): string | null {
+	const previewMatch = hostname.match(/^(\d+)\.dev\.m3tacron\.com$/i);
+	if (!previewMatch) {
+		return null;
+	}
+
+	return `https://${previewMatch[1]}.api.dev.m3tacron.com/api`;
+}
+
+export function resolveBackendApiBase(requestUrl?: URL): string {
+	const envBase = process.env.VITE_API_BASE;
+
+	if (envBase && !envBase.startsWith('/')) {
+		try {
+			const parsed = new URL(envBase);
+			if (!isLocalHostname(parsed.hostname)) {
+				return normalizeBackendApiBase(envBase);
+			}
+		} catch {
+			// Ignore malformed env values and fall back to request-derived hosts.
+		}
+	}
+
+	if (requestUrl) {
+		const previewBase = resolvePreviewBackendBase(requestUrl.hostname);
+		if (previewBase) {
+			return previewBase;
+		}
+	}
+
+	return 'http://backend:8888/api';
+}

--- a/frontend/src/routes/api/[...path]/+server.js
+++ b/frontend/src/routes/api/[...path]/+server.js
@@ -1,32 +1,9 @@
-function normalizeBackendApiBase(raw) {
-	const trimmed = String(raw || '').trim().replace(/\/+$/, '');
-	return trimmed.endsWith('/api') ? trimmed : `${trimmed}/api`;
-}
-
-function resolveBackendApiBase() {
-	const envBase = process.env.VITE_API_BASE;
-
-	if (!envBase || envBase.startsWith('/')) {
-		return 'http://backend:8888/api';
-	}
-
-	try {
-		const parsed = new URL(envBase);
-		if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
-			return 'http://backend:8888/api';
-		}
-		return normalizeBackendApiBase(envBase);
-	} catch {
-		return 'http://backend:8888/api';
-	}
-}
-
-const BACKEND_API_BASE = resolveBackendApiBase();
+import { resolveBackendApiBase } from '$lib/server/backend-api';
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET({ params, url, fetch, request }) {
 	const path = params.path || '';
-	const target = new URL(`${BACKEND_API_BASE}/${path}`);
+	const target = new URL(`${resolveBackendApiBase(url)}/${path}`);
 
 	for (const [key, value] of url.searchParams.entries()) {
 		target.searchParams.append(key, value);

--- a/frontend/src/routes/api/[...path]/+server.js
+++ b/frontend/src/routes/api/[...path]/+server.js
@@ -2,12 +2,26 @@ import { resolveBackendApiBase } from '$lib/server/backend-api';
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET({ params, url }) {
-	const path = params.path || '';
-	const target = new URL(`${resolveBackendApiBase(url)}/${path}`);
+	try {
+		const path = params.path || '';
+		const target = new URL(`${resolveBackendApiBase(url)}/${path}`);
 
-	for (const [key, value] of url.searchParams.entries()) {
-		target.searchParams.append(key, value);
+		for (const [key, value] of url.searchParams.entries()) {
+			target.searchParams.append(key, value);
+		}
+
+		return Response.redirect(target.toString(), 307);
+	} catch (error) {
+		return new Response(
+			JSON.stringify({
+				error: error instanceof Error ? error.message : String(error)
+			}),
+			{
+				status: 500,
+				headers: {
+					'content-type': 'application/json'
+				}
+			}
+		);
 	}
-
-	return Response.redirect(target.toString(), 307);
 }

--- a/frontend/src/routes/api/[...path]/+server.js
+++ b/frontend/src/routes/api/[...path]/+server.js
@@ -1,7 +1,7 @@
 import { resolveBackendApiBase } from '$lib/server/backend-api';
 
 /** @type {import('./$types').RequestHandler} */
-export async function GET({ params, url, fetch, request }) {
+export async function GET({ params, url }) {
 	const path = params.path || '';
 	const target = new URL(`${resolveBackendApiBase(url)}/${path}`);
 
@@ -9,20 +9,5 @@ export async function GET({ params, url, fetch, request }) {
 		target.searchParams.append(key, value);
 	}
 
-	const upstream = await fetch(target.toString(), {
-		method: 'GET',
-		headers: {
-			accept: request.headers.get('accept') || 'application/json'
-		}
-	});
-
-	const body = await upstream.arrayBuffer();
-	const headers = new Headers();
-	const contentType = upstream.headers.get('content-type');
-	if (contentType) headers.set('content-type', contentType);
-
-	return new Response(body, {
-		status: upstream.status,
-		headers
-	});
+	return Response.redirect(target.toString(), 307);
 }

--- a/frontend/src/routes/api/meta-snapshot/+server.ts
+++ b/frontend/src/routes/api/meta-snapshot/+server.ts
@@ -1,16 +1,47 @@
-import { json } from '@sveltejs/kit';
-import { API_BASE } from '$lib/api';
+function normalizeBackendApiBase(raw: string | undefined) {
+	const trimmed = String(raw || '').trim().replace(/\/+$/, '');
+	return trimmed.endsWith('/api') ? trimmed : `${trimmed}/api`;
+}
 
-export async function GET({ url, fetch }) {
-    const source = url.searchParams.get('data_source') || 'xwa';
-    try {
-        const res = await fetch(`${API_BASE}/meta-snapshot?data_source=${source}`);
-        if (!res.ok) {
-            throw new Error(`Backend error: ${res.status}`);
-        }
-        const data = await res.json();
-        return json(data);
-    } catch (e) {
-        return json({ error: String(e) }, { status: 500 });
-    }
+function resolveBackendApiBase() {
+	const envBase = process.env.VITE_API_BASE;
+
+	if (!envBase || envBase.startsWith('/')) {
+		return 'http://backend:8888/api';
+	}
+
+	try {
+		const parsed = new URL(envBase);
+		if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+			return 'http://backend:8888/api';
+		}
+		return normalizeBackendApiBase(envBase);
+	} catch {
+		return 'http://backend:8888/api';
+	}
+}
+
+const BACKEND_API_BASE = resolveBackendApiBase();
+
+export async function GET({ url, fetch, request }) {
+	const source = url.searchParams.get('data_source') || 'xwa';
+	const target = new URL(`${BACKEND_API_BASE}/meta-snapshot`);
+	target.searchParams.set('data_source', source);
+
+	const upstream = await fetch(target.toString(), {
+		method: 'GET',
+		headers: {
+			accept: request.headers.get('accept') || 'application/json'
+		}
+	});
+
+	const body = await upstream.arrayBuffer();
+	const headers = new Headers();
+	const contentType = upstream.headers.get('content-type');
+	if (contentType) headers.set('content-type', contentType);
+
+	return new Response(body, {
+		status: upstream.status,
+		headers
+	});
 }

--- a/frontend/src/routes/api/meta-snapshot/+server.ts
+++ b/frontend/src/routes/api/meta-snapshot/+server.ts
@@ -1,31 +1,8 @@
-function normalizeBackendApiBase(raw: string | undefined) {
-	const trimmed = String(raw || '').trim().replace(/\/+$/, '');
-	return trimmed.endsWith('/api') ? trimmed : `${trimmed}/api`;
-}
-
-function resolveBackendApiBase() {
-	const envBase = process.env.VITE_API_BASE;
-
-	if (!envBase || envBase.startsWith('/')) {
-		return 'http://backend:8888/api';
-	}
-
-	try {
-		const parsed = new URL(envBase);
-		if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
-			return 'http://backend:8888/api';
-		}
-		return normalizeBackendApiBase(envBase);
-	} catch {
-		return 'http://backend:8888/api';
-	}
-}
-
-const BACKEND_API_BASE = resolveBackendApiBase();
+import { resolveBackendApiBase } from '$lib/server/backend-api';
 
 export async function GET({ url, fetch, request }) {
 	const source = url.searchParams.get('data_source') || 'xwa';
-	const target = new URL(`${BACKEND_API_BASE}/meta-snapshot`);
+	const target = new URL(`${resolveBackendApiBase(url)}/meta-snapshot`);
 	target.searchParams.set('data_source', source);
 
 	const upstream = await fetch(target.toString(), {

--- a/frontend/src/routes/api/meta-snapshot/+server.ts
+++ b/frontend/src/routes/api/meta-snapshot/+server.ts
@@ -1,9 +1,23 @@
 import { resolveBackendApiBase } from '$lib/server/backend-api';
 
 export async function GET({ url }) {
-	const source = url.searchParams.get('data_source') || 'xwa';
-	const target = new URL(`${resolveBackendApiBase(url)}/meta-snapshot`);
-	target.searchParams.set('data_source', source);
+	try {
+		const source = url.searchParams.get('data_source') || 'xwa';
+		const target = new URL(`${resolveBackendApiBase(url)}/meta-snapshot`);
+		target.searchParams.set('data_source', source);
 
-	return Response.redirect(target.toString(), 307);
+		return Response.redirect(target.toString(), 307);
+	} catch (error) {
+		return new Response(
+			JSON.stringify({
+				error: error instanceof Error ? error.message : String(error)
+			}),
+			{
+				status: 500,
+				headers: {
+					'content-type': 'application/json'
+				}
+			}
+		);
+	}
 }

--- a/frontend/src/routes/api/meta-snapshot/+server.ts
+++ b/frontend/src/routes/api/meta-snapshot/+server.ts
@@ -1,24 +1,9 @@
 import { resolveBackendApiBase } from '$lib/server/backend-api';
 
-export async function GET({ url, fetch, request }) {
+export async function GET({ url }) {
 	const source = url.searchParams.get('data_source') || 'xwa';
 	const target = new URL(`${resolveBackendApiBase(url)}/meta-snapshot`);
 	target.searchParams.set('data_source', source);
 
-	const upstream = await fetch(target.toString(), {
-		method: 'GET',
-		headers: {
-			accept: request.headers.get('accept') || 'application/json'
-		}
-	});
-
-	const body = await upstream.arrayBuffer();
-	const headers = new Headers();
-	const contentType = upstream.headers.get('content-type');
-	if (contentType) headers.set('content-type', contentType);
-
-	return new Response(body, {
-		status: upstream.status,
-		headers
-	});
+	return Response.redirect(target.toString(), 307);
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -34,19 +34,35 @@ function resolveApiProxyTarget() {
 }
 
 function resolveAllowedHosts() {
-	const raw = process.env.VITE_ALLOWED_HOSTS;
-	if (!raw) {
-		const fallback = ['localhost', '127.0.0.1', '.dev.m3tacron.com'];
-		logConfig('VITE_ALLOWED_HOSTS_RAW', raw);
-		logConfig('VITE_ALLOWED_HOSTS_RESOLVED', fallback);
-		return fallback;
+	const hosts = new Set(['localhost', '127.0.0.1']);
+	const sources = [
+		process.env.ORIGIN,
+		process.env.COOLIFY_URL,
+		process.env.VITE_API_BASE,
+		process.env.VITE_PROXY_TARGET
+	];
+
+	for (const source of sources) {
+		if (!source) continue;
+		try {
+			hosts.add(new URL(source).hostname);
+		} catch {
+			continue;
+		}
 	}
 
-	const resolved = raw
-		.split(',')
-		.map((host) => host.trim())
-		.filter(Boolean);
+	const raw = process.env.VITE_ALLOWED_HOSTS;
+	if (raw) {
+		raw
+			.split(',')
+			.map((host) => host.trim())
+			.filter(Boolean)
+			.forEach((host) => hosts.add(host));
+	} else {
+		hosts.add('.dev.m3tacron.com');
+	}
 
+	const resolved = Array.from(hosts);
 	logConfig('VITE_ALLOWED_HOSTS_RAW', raw);
 	logConfig('VITE_ALLOWED_HOSTS_RESOLVED', resolved);
 	return resolved;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -36,9 +36,10 @@ function resolveApiProxyTarget() {
 function resolveAllowedHosts() {
 	const raw = process.env.VITE_ALLOWED_HOSTS;
 	if (!raw) {
+		const fallback = ['localhost', '127.0.0.1', '.dev.m3tacron.com'];
 		logConfig('VITE_ALLOWED_HOSTS_RAW', raw);
-		logConfig('VITE_ALLOWED_HOSTS_RESOLVED', undefined);
-		return undefined;
+		logConfig('VITE_ALLOWED_HOSTS_RESOLVED', fallback);
+		return fallback;
 	}
 
 	const resolved = raw


### PR DESCRIPTION
## Summary\n\nAdd in-memory response caching across the backend API to reduce repeated aggregation work and improve page load times. This includes cached analytics endpoints, detail endpoints, and a manual cache invalidation route for data refreshes.\n\n## Changes\n\n- Add backend/cache.py with a reusable TTL-based caching decorator\n- Cache major API endpoints and detail routes\n- Add POST /api/cache/invalidate for manual cache clearing\n- Document the caching behavior in CACHING.md